### PR TITLE
introduced enum for plot types

### DIFF
--- a/src/main/java/org/math/plot/DataSelectPanel.java
+++ b/src/main/java/org/math/plot/DataSelectPanel.java
@@ -787,13 +787,13 @@ public class DataSelectPanel extends JPanel {
                 System.err.println("plotting ...");
                 if (pp.getPlots().size() == 0) {
                     System.err.println("   new");
-                    pp.addPlot("SCATTER", "data", pp.mapData(getSelectedProjectedData()));
+                    pp.addPlot(PlotPanel.Type.SCATTER, "data", pp.mapData(getSelectedProjectedData()));
                 } else {
                     System.err.println(" existing");
                     if (from != null && from.endsWith("axis")) {
                         pp.resetMapData();
                         pp.removeAllPlots();
-                        pp.addPlot("SCATTER", "data", pp.mapData(getSelectedProjectedData()));
+                        pp.addPlot(PlotPanel.Type.SCATTER, "data", pp.mapData(getSelectedProjectedData()));
                     } else {
                         pp.getPlot(0).setData(pp.mapData(getSelectedProjectedData()));
                     }

--- a/src/main/java/org/math/plot/DataSelectTable.java
+++ b/src/main/java/org/math/plot/DataSelectTable.java
@@ -626,12 +626,12 @@ public class DataSelectTable extends JPanel {
 				pp.setAxisLabel(2, getSelectedZAxis());
 
 				if (pp.getPlots().size() == 0)
-					pp.addPlot("SCATTER", "data", pp.mapData(getSelectedProjectedData()));
+					pp.addPlot(PlotPanel.Type.SCATTER, "data", pp.mapData(getSelectedProjectedData()));
 				else {
 					if (from.endsWith("axis")) {
 						pp.resetMapData();
 						pp.removeAllPlots();
-						pp.addPlot("SCATTER", "data", pp.mapData(getSelectedProjectedData()));
+						pp.addPlot(PlotPanel.Type.SCATTER, "data", pp.mapData(getSelectedProjectedData()));
 					} else
 						pp.getPlot(0).setData(pp.mapData(getSelectedProjectedData()));
 				}

--- a/src/main/java/org/math/plot/Plot2DPanel.java
+++ b/src/main/java/org/math/plot/Plot2DPanel.java
@@ -381,21 +381,22 @@ public class Plot2DPanel extends PlotPanel {
     }
     
     @Override
-    public int addPlot(String type, String name, Color color, double[]... XY) {
-        if (type.equalsIgnoreCase(SCATTER)) {
-            return addScatterPlot(name, color, XY);
-        } else if (type.equalsIgnoreCase(LINE)) {
-            return addLinePlot(name, color, XY);
-        } else if (type.equalsIgnoreCase(BAR)) {
-            return addBarPlot(name, color, XY);
-        } else if (type.equalsIgnoreCase(STAIRCASE)) {
-            return addStaircasePlot(name, color, XY);
-        } else if (type.equalsIgnoreCase(HISTOGRAM)) {
-            return addHistogramPlot(name, color, XY);
-        } else if (type.equalsIgnoreCase(BOX)) {
-            return addBoxPlot(name, color, XY);
-        } else {
-            throw new IllegalArgumentException("Plot type is unknown : " + type);
+    public int addPlot(Type type, String name, Color color, double[]... XY) {
+        switch ( type ) {
+            case SCATTER:
+                return addScatterPlot(name, color, XY);
+            case LINE:
+                return addLinePlot(name, color, XY);
+            case BAR:
+                return addBarPlot(name, color, XY);
+            case STAIRCASE:
+                return addStaircasePlot(name, color, XY);
+            case HISTOGRAM:
+                return addHistogramPlot(name, color, XY);
+            case BOX:
+                return addBoxPlot(name, color, XY);
+            default:
+                throw new IllegalArgumentException("Plot type is unknown : " + type);
         }
     }
     

--- a/src/main/java/org/math/plot/Plot3DPanel.java
+++ b/src/main/java/org/math/plot/Plot3DPanel.java
@@ -232,21 +232,22 @@ public class Plot3DPanel extends PlotPanel {
     }
 
     @Override
-    public int addPlot(String type, String name, Color c, double[]... XY) {
-        if (type.equalsIgnoreCase(SCATTER)) {
-            return addScatterPlot(name, c, XY);
-        } else if (type.equalsIgnoreCase(LINE)) {
-            return addLinePlot(name, c, XY);
-        } else if (type.equalsIgnoreCase(BAR)) {
-            return addBarPlot(name, c, XY);
-        } else if (type.equalsIgnoreCase(HISTOGRAM)) {
-            return addHistogramPlot(name, c, XY);
-        } else if (type.equalsIgnoreCase(BOX)) {
-            return addBoxPlot(name, c, XY);
-        } else if (type.equalsIgnoreCase(GRID)) {
-            return addGridPlot(name, c, XY);
-        } else {
-            throw new IllegalArgumentException("Plot type is unknown : " + type);
+    public int addPlot(Type type, String name, Color color, double[]... XY) {
+        switch ( type ) {
+            case SCATTER:
+                return addScatterPlot(name, color, XY);
+            case LINE:
+                return addLinePlot(name, color, XY);
+            case BAR:
+                return addBarPlot(name, color, XY);
+            case HISTOGRAM:
+                return addHistogramPlot(name, color, XY);
+            case BOX:
+                return addBoxPlot(name, color, XY);
+            case GRID:
+                return addGridPlot(name, color, XY);
+            default:
+                throw new IllegalArgumentException("Plot type is unknown : " + type);
         }
     }
 

--- a/src/main/java/org/math/plot/PlotPanel.java
+++ b/src/main/java/org/math/plot/PlotPanel.java
@@ -32,22 +32,21 @@ import org.math.plot.utils.Array;
  */
 public abstract class PlotPanel extends JPanel {
 
+    public enum Type {
+        SCATTER, LINE, BAR, HISTOGRAM, BOX, STAIRCASE, GRID;
+    }
+
     private static final long serialVersionUID = 1L;
     public PlotToolBar plotToolBar;
     public PlotCanvas plotCanvas;
     public LegendPanel plotLegend;
+
     public final static String EAST = BorderLayout.EAST;
     public final static String SOUTH = BorderLayout.SOUTH;
     public final static String NORTH = BorderLayout.NORTH;
     public final static String WEST = BorderLayout.WEST;
     public final static String INVISIBLE = "INVISIBLE";
-    public final static String SCATTER = "SCATTER";
-    public final static String LINE = "LINE";
-    public final static String BAR = "BAR";
-    public final static String HISTOGRAM = "HISTOGRAM";
-    public final static String BOX = "BOX";
-    public final static String STAIRCASE = "STAIRCASE";
-    public final static String GRID = "GRID";
+
     public final static Color[] COLORLIST = {Color.BLUE, Color.RED, Color.GREEN, Color.YELLOW, Color.ORANGE, Color.PINK, Color.CYAN, Color.MAGENTA};
     private Font font = new Font("Arial", Font.PLAIN, 10);
 
@@ -383,11 +382,11 @@ public abstract class PlotPanel extends JPanel {
         return COLORLIST[plotCanvas.plots.size() % COLORLIST.length];
     }
 
-    public int addPlot(String type, String name, double[]... v) {
+    public int addPlot(Type type, String name, double[]... v) {
         return addPlot(type, name, getNewColor(), v);
     }
 
-    public abstract int addPlot(String type, String name, Color c, double[]... v);
+    public abstract int addPlot(Type type, String name, Color c, double[]... v);
 
     public void setPlot(int I, Plot p) {
         plotCanvas.setPlot(I, p);
@@ -494,7 +493,7 @@ public abstract class PlotPanel extends JPanel {
         try {
 
             String leg = "INVISIBLE";
-            String type = SCATTER;
+            String type = "SCATTER";
             String name = "";
 
             double[][] v = null;
@@ -580,7 +579,10 @@ public abstract class PlotPanel extends JPanel {
                                 n = p2d.addCloudPlot(name, ASCIIFile.readDoubleArray(input_file), Integer.parseInt(type.substring(8, type.indexOf(","))),
                                         Integer.parseInt(type.substring(type.indexOf(",") + 1, type.length() - 1)));
                             } else {
-                                p2d.addPlot(type, name, ASCIIFile.readDoubleArray(input_file));
+                                for (Type t : Type.values()) {
+                                    if (t.name().equalsIgnoreCase(type))
+                                        p2d.addPlot(t, name, ASCIIFile.readDoubleArray(input_file));
+                                }
                             }
                         } else {
                             Plot3DPanel p3d = (Plot3DPanel) p;
@@ -599,7 +601,10 @@ public abstract class PlotPanel extends JPanel {
                                 n = p3d.addCloudPlot(name, ASCIIFile.readDoubleArray(input_file), Integer.parseInt(type.substring(8, type.indexOf(","))),
                                         Integer.parseInt(type.substring(type.indexOf(",") + 1, type.indexOf(",", type.indexOf(",") + 1))), Integer.parseInt(type.substring(type.indexOf(",", type.indexOf(",") + 1) + 1, type.length() - 1)));
                             } else {
-                                p3d.addPlot(type, name, ASCIIFile.readDoubleArray(input_file));
+                                for (Type t : Type.values()) {
+                                    if (t.name().equalsIgnoreCase(type))
+                                        p3d.addPlot(t, name, ASCIIFile.readDoubleArray(input_file));
+                                }
                             }
                         }
 


### PR DESCRIPTION
I introduced an enum for all plot types (`PlotPanel.Type`).
That way we have stronger typing than with Strings and the plot types are iterable.
The function `addPlot(String, String, Color, double[]...)` in `Plot2DPanel` and `Plot3DPanel` becomes much more readable.
A few changes to the demos were necessary as well.