### PR TITLE
Fix bug with lost values on bounds and little optimization

### DIFF
--- a/src/main/java/org/math/plot/utils/Histogram.java
+++ b/src/main/java/org/math/plot/utils/Histogram.java
@@ -26,8 +26,9 @@ public class Histogram {
 		double[] h = new double[bounds.length - 1];
 		for (int i = 0; i < values.length; i++) {
 			for (int j = 0; j < h.length; j++) {
-				if (((bounds[j + 1] - values[i]) * (bounds[j] - values[i]) < 0) || ((bounds[j] == values[i])))
+				if (((bounds[j + 1] - values[i]) * (bounds[j] - values[i]) <= 0) || ((bounds[j] == values[i])))
 					h[j]++;
+					break;
 			}
 		}
 		return h;


### PR DESCRIPTION
## Problem code
https://github.com/yannrichet/jmathplot/blob/cc3eb20f99e29ff39c2d6b9c6e112a63e2c37d8b/src/main/java/org/math/plot/utils/Histogram.java#L27-L32

## Description of the bug
Sometimes happens what some values just losing on distribution intervals.

## Optimization
Obviously, one value cannot contain several different boundaries. That's why after that we have to break out the inner cycle.

## Proposed solution
```java
for (int i = 0; i < values.length; i++) {
	for (int j = 0; j < h.length; j++) {
		if (((bounds[j + 1] - values[i]) * (bounds[j] - values[i]) <= 0) || ((bounds[j] == values[i])))
			h[j]++;
			break;
	}
}
```